### PR TITLE
Cleanup lyric output

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,11 +21,8 @@ async function GetLyric(url) {
 		var html = await request(url)
 		var raw = lpattern.exec(html.body)
 		var res = raw[1].replace(/\<br\>/g," ");
-                res = res.replace(/\<i\>\[Hook(.*)\]<\/i\>/g, " ");
-                res = res.replace(/\<i\>\[Intro(.*)\]<\/i\>/g, " ");
-                res = res.replace(/\<i\>\[Pre-Chorus:\]\<\/i\>/g," ");
-		res = res.replace(/\<i\>\[Chorus:\]\<\/i\>/g," ");
-		res = res.replace(/\<i\>\[Verse(.*)\]<\/i\>/g, " ");
+		res = res.replace(/<i\>(.*)<\/i\>/g, " ");
+		res = res.replace(/\<\/div\>/g, " ");
 		console.log(res)
 	}
 	catch (e) {

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ async function GetLyric(url) {
 		var raw = lpattern.exec(html.body)
 		var res = raw[1].replace(/\<br\>/g," ");
 		res = res.replace(/<i\>(.*)<\/i\>/g, " ");
+		res = res.replace(/(?=)(\&quot\;)/g, "\"");
 		res = res.replace(/\<\/div\>/g, " ");
 		console.log(res)
 	}

--- a/index.js
+++ b/index.js
@@ -21,8 +21,11 @@ async function GetLyric(url) {
 		var html = await request(url)
 		var raw = lpattern.exec(html.body)
 		var res = raw[1].replace(/\<br\>/g," ");
+                res = res.replace(/\<i\>\[Hook(.*)\]<\/i\>/g, " ");
+                res = res.replace(/\<i\>\[Intro(.*)\]<\/i\>/g, " ");
+                res = res.replace(/\<i\>\[Pre-Chorus:\]\<\/i\>/g," ");
 		res = res.replace(/\<i\>\[Chorus:\]\<\/i\>/g," ");
-		res = res.replace(/\<i\>\[Pre-Chorus:\]\<\/i\>/g," ");
+		res = res.replace(/\<i\>\[Verse(.*)\]<\/i\>/g, " ");
 		console.log(res)
 	}
 	catch (e) {


### PR DESCRIPTION
- Handles clean removal of all the `<i>[Tag]</i>` which can contain various things (Chorus, Hook, Verse, etc. - they are also not in a standard format, i.e. it can be `[Verse 3:]` or `[Verse - 3:]` or `[Verse 3: Artist]` so we remove all and replace with a space for cleanliness)

- Remove the trailing `</div>` at the end of all queries left after HTML parsing

- Handle `&quot;SomeLyricsHere&quot;` and replace the `&quot;` with `"` as it should be, i.e. replace `&quot;Lyrics&quot;` with `"Lyrics"`

Tested with various songs, handles all cases.
